### PR TITLE
Fix Google Font import to include Syne Mono

### DIFF
--- a/oldbook.css
+++ b/oldbook.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel&family=Cinzel+Decorative&family=IM+Fell+DW+Pica+SC&family=IM+Fell+DW+Pica:ital@0;1&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IM+Fell+DW+Pica+SC&family=IM+Fell+DW+Pica:ital@0;1&family=Syne+Mono&display=swap');
 
 html {
 	background-color: #fff3c9;


### PR DESCRIPTION
Looks like the URL was missing Syne Mono, which is used with the code element